### PR TITLE
Fix bundle info plist

### DIFF
--- a/AffirmSDK.xcodeproj/project.pbxproj
+++ b/AffirmSDK.xcodeproj/project.pbxproj
@@ -559,7 +559,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "$(SRCROOT)/AffirmSDK/AffirmSDK.bundle/Info.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/AffirmSDK/Carthage/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -583,7 +583,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "$(SRCROOT)/AffirmSDK/AffirmSDK.bundle/Info.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/AffirmSDK/Carthage/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/AffirmSDK/AffirmSDK.bundle/Info.plist
+++ b/AffirmSDK/AffirmSDK.bundle/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>BNDL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>5.0.2</string>
 	<key>CFBundleVersion</key>

--- a/AffirmSDK/AffirmSDK.bundle/Info.plist
+++ b/AffirmSDK/AffirmSDK.bundle/Info.plist
@@ -11,7 +11,9 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
+	<string>BNDL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
 	<key>CFBundleShortVersionString</key>
 	<string>5.0.2</string>
 	<key>CFBundleVersion</key>

--- a/AffirmSDK/AffirmSDK.bundle/Info.plist
+++ b/AffirmSDK/AffirmSDK.bundle/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<string>en</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/AffirmSDK/AffirmSDK.bundle/Info.plist
+++ b/AffirmSDK/AffirmSDK.bundle/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -13,7 +11,7 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
+	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>5.0.2</string>
 	<key>CFBundleVersion</key>

--- a/AffirmSDK/AffirmSDK.bundle/Info.plist
+++ b/AffirmSDK/AffirmSDK.bundle/Info.plist
@@ -18,5 +18,9 @@
 	<string>5.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>5.0.2</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2017 Affirm. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/AffirmSDK/AffirmSDK.bundle/Info.plist
+++ b/AffirmSDK/AffirmSDK.bundle/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -12,15 +12,9 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleShortVersionString</key>
 	<string>5.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>5.0.2</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2017 Affirm. All rights reserved.</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
 </dict>
 </plist>

--- a/AffirmSDK/Carthage/Info.plist
+++ b/AffirmSDK/Carthage/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/AffirmSDK/Carthage/Info.plist
+++ b/AffirmSDK/Carthage/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleShortVersionString</key>
+	<string>5.0.2</string>
+	<key>CFBundleVersion</key>
+	<string>5.0.2</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2017 Affirm. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/AffirmSDK/Carthage/Info.plist
+++ b/AffirmSDK/Carthage/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -14,15 +14,9 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleShortVersionString</key>
 	<string>5.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>5.0.2</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2017 Affirm. All rights reserved.</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #17 
- Created a Carthage-specific Info.plist
- Removed CFBundleExecutable from AffirmSDK.bundle/Info.plist
- Updated both plist's CFBundlePackageType to be `BNDL` instead of `FMWK`

It's worth noting that the CFBundleVersion and CFBundleShortVersionString will need to be updated in both AffirmSDK.bundle/Info.plist and Carthage/Info.plist going forward, similar to how it is done in the [Affirm/affirm-ios-sdk](affirm-ios-sdk) project.