### PR TITLE
Update `AffirmDataHandler.getPromoMessageWithPromoID` Parameters

### DIFF
--- a/AffirmSDK/AffirmDataHandler.h
+++ b/AffirmSDK/AffirmDataHandler.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param colorType color of Affirm to display (blue, black, white) - only applies to logo and symbol affirmType values
  @param font the font of button title, maxFontSize will be set as same value
  @param textColor the color of button title
- @param presentingViewController view controller that button is displayed on, and the view controller must follow the AffirmPrequalDelegate
+ @param delegate custom implementation of AffirmPrequalDelegate
  @param completionHandler the completion handler
  */
 + (void)getPromoMessageWithPromoID:(nullable NSString *)promoID
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
                          colorType:(AffirmColorType)colorType
                               font:(UIFont *)font
                          textColor:(UIColor *)textColor
-          presentingViewController:(UIViewController<AffirmPrequalDelegate> *)presentingViewController
+          presentingViewController:(id<AffirmPrequalDelegate>)delegate
                  completionHandler:(void (^)(NSAttributedString * _Nullable , UIViewController * _Nullable, NSError * _Nullable))completionHandler
 NS_SWIFT_NAME(getPromoMessage(promoID:amount:showCTA:pageType:logoType:colorType:font:textColor:presentingViewController:completionHandler:));
 

--- a/AffirmSDK/AffirmDataHandler.m
+++ b/AffirmSDK/AffirmDataHandler.m
@@ -23,7 +23,7 @@
                          colorType:(AffirmColorType)colorType
                               font:(UIFont *)font
                          textColor:(UIColor *)textColor
-          presentingViewController:(UIViewController<AffirmPrequalDelegate> *)presentingViewController
+          presentingViewController:(id<AffirmPrequalDelegate>)presentingViewController
                  completionHandler:(void (^)(NSAttributedString * _Nullable , UIViewController * _Nullable, NSError * _Nullable))completionHandler
 {
     [AffirmValidationUtils checkNotNil:amount name:@"amount"];

--- a/AffirmSDK/AffirmDataHandler.m
+++ b/AffirmSDK/AffirmDataHandler.m
@@ -23,7 +23,7 @@
                          colorType:(AffirmColorType)colorType
                               font:(UIFont *)font
                          textColor:(UIColor *)textColor
-          presentingViewController:(id<AffirmPrequalDelegate>)presentingViewController
+          presentingViewController:(id<AffirmPrequalDelegate>)delegate
                  completionHandler:(void (^)(NSAttributedString * _Nullable , UIViewController * _Nullable, NSError * _Nullable))completionHandler
 {
     [AffirmValidationUtils checkNotNil:amount name:@"amount"];
@@ -69,11 +69,11 @@
                 NSString *url = [NSString stringWithFormat:@"%@/apps/prequal/", [AffirmCheckoutClient host]];
                 NSURL *requestURL = [NSURL URLWithString:[NSString stringWithFormat:@"?%@", [params queryURLEncoding]]
                                            relativeToURL:[NSURL URLWithString:url]];
-                viewController = [[AffirmPrequalModalViewController alloc] initWithURL:requestURL delegate:presentingViewController];
+                viewController = [[AffirmPrequalModalViewController alloc] initWithURL:requestURL delegate:delegate];
             } else {
                 viewController = [[AffirmPromoModalViewController alloc] initWithPromoId:promoID
                                                                                   amount:decimal
-                                                                                delegate:presentingViewController];
+                                                                                delegate:delegate];
             }
         }
         completionHandler(attributedString, viewController, error);


### PR DESCRIPTION
# Description
This PR updates the `presentingViewController` parameter that is of type `(UIViewController & AffirmPrequalDelegate)` to a much similar and concise `delegate` parameter of type `AffirmPrequalDelegate`. The places that take in the the `presentingViewController` (`AffirmPrequalModalViewController` and `AffirmPromoModalViewController`) only require a value of `AffirmPrequalDelegate` so we shouldn't be required to pass in a `(UIViewController & AffirmPrequalDelegate)` by not requiring this simplifies the use of this method in architectures that are not MVC such as MVVM. 