### PR TITLE
Add HTML Support

### DIFF
--- a/AffirmSDK/AffirmDataHandler.h
+++ b/AffirmSDK/AffirmDataHandler.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Get the contents of an Affirm as low as object which describes the merchant and the item.
-
+ 
  @param promoID Promo ID to use when getting terms (provided by Affirm)
  @param amount Amount of the transaction
  @param showCTA A boolean to use when getting terms
@@ -41,7 +41,7 @@ NS_SWIFT_NAME(getPromoMessage(promoID:amount:showCTA:pageType:logoType:colorType
 
 /**
  Get the contents of an Affirm as low as object which describes the merchant and the item.
-
+ 
  @param promoID Promo ID to use when getting terms (provided by Affirm)
  @param amount Amount of the transaction
  @param showCTA A boolean to use when getting terms
@@ -67,7 +67,35 @@ NS_SWIFT_NAME(getPromoMessage(promoID:amount:showCTA:pageType:logoType:colorType
                  completionHandler:(void (^)(NSAttributedString * _Nullable , UIViewController * _Nullable, NSError * _Nullable))completionHandler
 NS_SWIFT_NAME(getPromoMessage(promoID:amount:showCTA:pageType:logoType:colorType:font:textColor:presentingViewController:withNavigation:completionHandler:));
 
-
+/**
+ Get the contents of an Affirm as low as object which describes the merchant and the item.
+ 
+ @param promoID Promo ID to use when getting terms (provided by Affirm)
+ @param amount Amount of the transaction
+ @param showCTA A boolean to use when getting terms
+ @param pageType type of Affirm page to display
+ @param logoType type of Affirm logo to display (text, name, symbol)
+ @param colorType color of Affirm to display (blue, black, white) - only applies to logo and symbol affirmType values
+ @param font the font of button title, maxFontSize will be set as same value
+ @param textColor the color of button title
+ @param delegate custom implementation of AffirmPrequalDelegate
+ @param withNavigation whether to return UINavigationController including promo modal
+ @param withHtmlValue whether to return html raw string
+ @param completionHandler the completion handler
+ */
++ (void)getPromoMessageWithPromoID:(nullable NSString *)promoID
+                            amount:(NSDecimalNumber *)amount
+                           showCTA:(BOOL)showCTA
+                          pageType:(AffirmPageType)pageType
+                          logoType:(AffirmLogoType)logoType
+                         colorType:(AffirmColorType)colorType
+                              font:(UIFont *)font
+                         textColor:(UIColor *)textColor
+          presentingViewController:(id<AffirmPrequalDelegate>)delegate
+                    withNavigation:(BOOL)withNavigation
+                     withHtmlValue:(BOOL)withHtmlValue
+                 completionHandler:(void (^)(NSAttributedString * _Nullable, NSString * _Nullable, UIViewController * _Nullable, NSError * _Nullable))completionHandler
+NS_SWIFT_NAME(getPromoMessage(promoID:amount:showCTA:pageType:logoType:colorType:font:textColor:presentingViewController:withNavigation:withHtmlValue:completionHandler:));
 
 @end
 

--- a/AffirmSDK/AffirmDataHandler.m
+++ b/AffirmSDK/AffirmDataHandler.m
@@ -102,7 +102,7 @@
         UIViewController *viewController = nil;
         if (response && [response isKindOfClass:[AffirmPromoResponse class]]) {
             AffirmPromoResponse *promoResponse = (AffirmPromoResponse *)response;
-            htmlValue = promoResponse.htmlAla;
+            htmlValue = withHtmlValue ? promoResponse.htmlAla : nil;
             
             NSString *template = nil;
             if (promoResponse.ala != nil && promoResponse.ala.length > 0) {

--- a/AffirmSDK/AffirmPromotionalButton.h
+++ b/AffirmSDK/AffirmPromotionalButton.h
@@ -234,6 +234,20 @@ NS_SWIFT_NAME(configure(amount:affirmLogoType:affirmColor:font:textColor:));
 - (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
+/**
+ Configures an AffirmPromotionalButton based on the HTML string
+
+ @param htmlString html raw string
+ @param amount Amount of the transaction
+ @param remoteFontURL Use a custom font file
+ @param remoteCssURL Use a custom css file
+ */
+- (void)configureWithHtmlString:(NSString *)htmlString
+                         amount:(NSDecimalNumber *)amount
+                  remoteFontURL:(nullable NSURL *)remoteFontURL
+                   remoteCssURL:(nullable NSURL *)remoteCssURL
+NS_SWIFT_NAME(configure(htmlString:amount:remoteFontURL:remoteCssURL:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Examples/Examples/ViewController.m
+++ b/Examples/Examples/ViewController.m
@@ -170,12 +170,15 @@
 - (void)configurPromotionalMessage
 {
     NSDecimalNumber *dollarPrice = [NSDecimalNumber decimalNumberWithString:self.amountTextField.text];
-    NSURL *url = [[NSBundle mainBundle] URLForResource:@"css_promo_sample" withExtension:@"css"];
-    [self.promotionalButton configureByHtmlStylingWithAmount:dollarPrice
-                                              affirmLogoType:AffirmLogoTypeName
-                                                 affirmColor:AffirmColorTypeBlueBlack
-                                               remoteFontURL:[NSURL URLWithString:@"https://fonts.googleapis.com/css?family=Saira+Stencil+One&display=swap"]
-                                                remoteCssURL:url];
+    NSURL *fontURL = [NSURL URLWithString:@"https://fonts.googleapis.com/css?family=Saira+Stencil+One&display=swap"];
+    NSURL *cssURL = [[NSBundle mainBundle] URLForResource:@"css_promo_sample" withExtension:@"css"];
+
+    // Configure promotionalButton with html styling automatically
+//    [self.promotionalButton configureByHtmlStylingWithAmount:dollarPrice
+//                                              affirmLogoType:AffirmLogoTypeName
+//                                                 affirmColor:AffirmColorTypeBlueBlack
+//                                               remoteFontURL:fontURL
+//                                                remoteCssURL:cssURL];
 
     [AffirmDataHandler getPromoMessageWithPromoID:nil
                                            amount:dollarPrice
@@ -187,10 +190,19 @@
                                         textColor:[UIColor grayColor]
                          presentingViewController:self
                                    withNavigation:YES
-                                completionHandler:^(NSAttributedString *attributedString, UIViewController *viewController, NSError *error) {
-                                    [self.promoButton setAttributedTitle:attributedString forState:UIControlStateNormal];
-                                    self.promoViewController = viewController;
-                                }];
+                                    withHtmlValue:YES
+                                completionHandler:^(NSAttributedString *attributedString, NSString *html, UIViewController *viewController, NSError *error) {
+
+        // Configure promotionalButton with html string manually
+        [self.promotionalButton configureWithHtmlString:html
+                                                 amount:dollarPrice
+                                          remoteFontURL:fontURL
+                                           remoteCssURL:cssURL];
+
+        // Configure native button using attributed string
+        [self.promoButton setAttributedTitle:attributedString forState:UIControlStateNormal];
+        self.promoViewController = viewController;
+    }];
 }
 
 - (void)configureTextField

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ To show / refresh promotional messaging, use
 [self.promotionalButton configureByHtmlStylingWithAmount:[NSDecimalNumber decimalNumberWithString:amountText]
                                           affirmLogoType:AffirmLogoTypeName
                                              affirmColor:AffirmColorTypeBlue
-                                           remoteFontURL:[NSURL URLWithString:@"https://fonts.googleapis.com/css?family=Saira+Stencil+One&display=swap"]
-                                            remoteCssURL:url];
+                                           remoteFontURL:fontURL
+                                            remoteCssURL:cssURL];
 ```
 or
 ```
@@ -118,6 +118,14 @@ self.promotionalButton.configure(amount: NSDecimalNumber(string: amountText),
                             affirmColor: .blue,
                                    font: UIFont.italicSystemFont(ofSize: 15),
                               textColor: .gray)
+```
+
+If you have got the html raw string, you could show the promotional messaging using
+```
+[self.promotionalButton configureWithHtmlString:html
+                                         amount:amount
+                                  remoteFontURL:fontURL
+                                   remoteCssURL:cssURL];
 ```
 
 If you want to use local fonts, you need do following steps:


### PR DESCRIPTION
@AmyBeall Added a new method in AffirmDataHandler. To get html, call it by passing `withHtmlValue` with `YES`.
```
[AffirmDataHandler getPromoMessageWithPromoID:nil
                                           amount:dollarPrice
                                          showCTA:YES
                                         pageType:AffirmPageTypeProduct
                                         logoType:AffirmLogoTypeName
                                        colorType:AffirmColorTypeBlueBlack
                                             font:[UIFont boldSystemFontOfSize:15]
                                        textColor:[UIColor grayColor]
                         presentingViewController:self
                                   withNavigation:YES
                                    withHtmlValue:YES
                                completionHandler:^(NSAttributedString *attributedString, NSString *htmlValue, UIViewController *viewController, NSError *error) {
        NSLog(@"HTML string: %@", htmlValue);
        [self.promoButton setAttributedTitle:attributedString forState:UIControlStateNormal];
        self.promoViewController = viewController;
    }];
```