### PR TITLE
Pass the correct iOS SDK version in the affirm-user-agent-version

### DIFF
--- a/AffirmSDK/AffirmConfiguration.m
+++ b/AffirmSDK/AffirmConfiguration.m
@@ -103,7 +103,7 @@
 
 + (NSString *)affirmSDKVersion
 {
-    return [[NSBundle resourceBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey];
+    return [[NSBundle resourceBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
 }
 
 - (NSString *)domain

--- a/AffirmSDK/AffirmSDK.bundle/Info.plist
+++ b/AffirmSDK/AffirmSDK.bundle/Info.plist
@@ -13,8 +13,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.3</string>
+	<string>5.0.13</string>
 	<key>CFBundleVersion</key>
-	<string>5.0.3</string>
+	<string>5.0.13</string>
 </dict>
 </plist>

--- a/AffirmSDK/Carthage/Info.plist
+++ b/AffirmSDK/Carthage/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.2</string>
+	<string>5.0.13</string>
 	<key>CFBundleVersion</key>
-	<string>5.0.2</string>
+	<string>5.0.13</string>
 </dict>
 </plist>


### PR DESCRIPTION
Note: Before deployment, please check the three places and update to the latest version number:

1. ProjectDir/AffirmSDK.podspec (For cocoapods)
2. ProjectDir/AffirmSDK/Carthage/Info.plist (For carthage)
3. ProjectDir/AffirmSDK/AffirmSDK.bundle (For sdk)