### PR TITLE
Bug when exiting modal

### DIFF
--- a/AffirmSDK/AffirmPromoModalViewController.m
+++ b/AffirmSDK/AffirmPromoModalViewController.m
@@ -59,7 +59,7 @@
 
     NSString *promoIdString = promoId ?: @"";
     NSString *pageTypeString = FormatAffirmPageTypeString(pageType) ?: @"";
-    _htmlString = [NSString stringWithFormat:rawContent, [AffirmConfiguration sharedInstance].publicKey, jsURL, amount, promoIdString, pageTypeString, promoIdString, AFFIRM_CHECKOUT_CANCELLATION_URL];
+    _htmlString = [NSString stringWithFormat:rawContent, [AffirmConfiguration sharedInstance].publicKey, jsURL, amount, promoIdString, pageTypeString, promoIdString, AFFIRM_PREQUAL_REFERRING_URL];
     _delegate = delegate;
 }
 


### PR DESCRIPTION
https://trello.com/c/4pj7nwa4/89-bug-when-exiting-modal

Warby Parker reported an issue where a user is unable to exit our edu modal.

They are currently on the latest iOS SDK

Steps to reproduce:
User selects learn more link from a product page in iOS app
User tries to exit by selecting the "X" icon
User experiences infinite spinning and must force quit the app in order to go back to the Warby Parker app (image attached)