### PR TITLE
Remove broken links

### DIFF
--- a/SPM/AffirmProtocol.h
+++ b/SPM/AffirmProtocol.h
@@ -1,1 +1,0 @@
-../AffirmSDK/AffirmProtocol.h

--- a/SPM/AffirmProtocol.m
+++ b/SPM/AffirmProtocol.m
@@ -1,1 +1,0 @@
-../AffirmSDK/AffirmProtocol.m


### PR DESCRIPTION
The files `SPM/AffirmProtocol.{h,m}` point to non-existing files and generates a warning when integrating the AffirmSDK via SPM.