### PR TITLE
Expand bridging headers to AffirmClient.h & AffirmRequest.h for SPM support

### DIFF
--- a/AffirmSDK/AffirmSDK.h
+++ b/AffirmSDK/AffirmSDK.h
@@ -41,3 +41,5 @@ FOUNDATION_EXPORT const unsigned char AffirmSDKVersionString[];
 #import "AffirmEligibilityViewController.h"
 #import "AffirmCardInfoViewController.h"
 #import "AffirmHowToViewController.h"
+#import "AffirmRequest.h"
+#import "AffirmClient.h"

--- a/SPM/AffirmProtocol.h
+++ b/SPM/AffirmProtocol.h
@@ -1,1 +1,0 @@
-../AffirmSDK/AffirmProtocol.h

--- a/SPM/AffirmProtocol.m
+++ b/SPM/AffirmProtocol.m
@@ -1,1 +1,0 @@
-../AffirmSDK/AffirmProtocol.m

--- a/SPM/include/AffirmClient.h
+++ b/SPM/include/AffirmClient.h
@@ -1,0 +1,1 @@
+../../AffirmSDK/AffirmClient.h

--- a/SPM/include/AffirmRequest.h
+++ b/SPM/include/AffirmRequest.h
@@ -1,0 +1,1 @@
+../../AffirmSDK/AffirmRequest.h


### PR DESCRIPTION
We are requesting a change to support the Affirm SDK SPM integration. 

Currently, `AffirmClient.h` & `AffirmRequest.h` are not included in the bridging header `AffirmSDK/AffirmSDK.h`. This makes it difficult to subclass in a client app. We were able to subclass through the SDK cocoapods.

To solve this problem, we added symlinks to these files. We edited the bridging header to include these files in the Swift package. 

Also branching from [dbarden:remove_broken_symlink](https://github.com/dbarden/affirm-merchant-sdk-ios/tree/remove_broken_symlink)
The files SPM/AffirmProtocol.{h,m} point to non-existing files and generates a warning when integrating the AffirmSDK via SPM.