### PR TITLE
update versions for release 5.0.25

### DIFF
--- a/AffirmSDK.podspec
+++ b/AffirmSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name						= 'AffirmSDK'
   s.authors						= "Affirm, Inc."
-  s.version						= '5.0.24'
+  s.version						= '5.0.25'
   s.summary						= 'Integrate Affirm into your iOS app'
   s.homepage					= 'https://github.com/Affirm/affirm-merchant-sdk-ios'
   s.license						= { :type => "BSD-3-Clause", :file => "LICENSE" }

--- a/AffirmSDK/AffirmSDK.bundle/Info.plist
+++ b/AffirmSDK/AffirmSDK.bundle/Info.plist
@@ -13,8 +13,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.24</string>
+	<string>5.0.25</string>
 	<key>CFBundleVersion</key>
-	<string>5.0.24</string>
+	<string>5.0.25</string>
 </dict>
 </plist>

--- a/AffirmSDK/Info.plist
+++ b/AffirmSDK/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.24</string>
+	<string>5.0.25</string>
 	<key>CFBundleVersion</key>
-	<string>5.0.24</string>
+	<string>5.0.25</string>
 </dict>
 </plist>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Affirm iOS SDK Changelog
 All notable changes to the SDK will be documented in this file.
 
+## Version 5.0.25 (January 19, 2023)
+- Bug fixes
+
 ## Version 5.0.24 (October 17, 2022)
 - Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ github "Affirm/affirm-merchant-sdk-ios"
 From Xcode 11+ :
 
 1. Select File > Swift Packages > Add Package Dependency. Enter `https://github.com/Affirm/affirm-merchant-sdk-ios` in the "Choose Package Repository" dialog.
-2. In the next page, specify the version resolving rule as "Up to Next Major" with "5.0.24".
+2. In the next page, specify the version resolving rule as "Up to Next Major" with "5.0.25".
 3. After Xcode checked out the source and resolving the version, you can choose the "AffirmSDK" library and add it to your app target.
 
 For more info, read [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app) from Apple.
@@ -38,7 +38,7 @@ Alternatively, you can also add AffirmSDK to your `Package.swift` file:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Affirm/affirm-merchant-sdk-ios", .upToNextMajor(from: "5.0.24"))
+    .package(url: "https://github.com/Affirm/affirm-merchant-sdk-ios", .upToNextMajor(from: "5.0.25"))
 ]
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,11 +3,11 @@ How to upgrade?
 If you want to upgrade you sdk to the lastest, please check the following points:
 
 ## Version
-The latest version is `v5.0.24`, you can upgrade sdk by [CocoaPods](https://cocoapods.org/) and [Carthage](https://github.com/Carthage/Carthage).
+The latest version is `v5.0.25`, you can upgrade sdk by [CocoaPods](https://cocoapods.org/) and [Carthage](https://github.com/Carthage/Carthage).
 
 For example:
 
-if you use [CocoaPods](https://cocoapods.org/), please make sure you pod repo contains `v5.0.24`, you can use `pod search AffirmSDK` to check it. Otherwise, you should update pod repo before upgrade.
+if you use [CocoaPods](https://cocoapods.org/), please make sure you pod repo contains `v5.0.25`, you can use `pod search AffirmSDK` to check it. Otherwise, you should update pod repo before upgrade.
 
 
 ## Fetch updated library
@@ -15,7 +15,7 @@ if you use [CocoaPods](https://cocoapods.org/), please make sure you pod repo co
 If you already use specific sdk version in Podfile, please modify the line related to affirmSDK as follows:
 
 ```
-pod 'AffirmSDK', '~> 5.0.24'
+pod 'AffirmSDK', '~> 5.0.25'
 ```
 
 Otherwise, just use `pod update AffirmSDK` in terminal to update AffirmSDK.


### PR DESCRIPTION
Updating versions for release 5.0.25 containing fixes for Expand Bridging Headers for SPM -  https://github.com/Affirm/affirm-merchant-sdk-ios/pull/128