### PR TITLE
updated cocoa pod link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 Affirm iOS SDK
 ==============
-[![CocoaPods](https://img.shields.io/cocoapods/v/AffirmSDK.svg)](http://cocoadocs.org/docsets/AffirmSDK) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![license](https://img.shields.io/cocoapods/l/AffirmSDK.svg)]()
+[![CocoaPods](https://img.shields.io/cocoapods/v/AffirmSDK.svg)](https://cocoapods.org/pods/AffirmSDK) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![license](https://img.shields.io/cocoapods/l/AffirmSDK.svg)]()
 
 The Affirm iOS SDK allows you to offer Affirm in your own app.
 


### PR DESCRIPTION
updated readme to fix broken link to the AffirmSDK cocoapod - https://cocoapods.org/pods/AffirmSDK 