### PR TITLE
update github actions runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
     - name: Checkout project
       uses: actions/checkout@v2

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
     - name: Checkout project
       uses: actions/checkout@v2


### PR DESCRIPTION
Updated the CI configs for Github Actions to use `macos-latest` instead of the now deprecated `macos-10.15`.

<img width="1268" alt="image" src="https://github.com/Affirm/affirm-merchant-sdk-ios/assets/41962315/9220f61a-d320-43db-9663-35e1e5540c44">


PR tests should now run and pass as expected (previously no runner was found and tests would stall until timeout)

