### PR TITLE
[IP-000] Fix the SDK Umbrella Header

### DIFF
--- a/AffirmSDK/AffirmSDK.h
+++ b/AffirmSDK/AffirmSDK.h
@@ -41,5 +41,3 @@ FOUNDATION_EXPORT const unsigned char AffirmSDKVersionString[];
 #import "AffirmEligibilityViewController.h"
 #import "AffirmCardInfoViewController.h"
 #import "AffirmHowToViewController.h"
-#import "AffirmRequest.h"
-#import "AffirmClient.h"


### PR DESCRIPTION
## Summary 

The umbrella header file does not need `AffirmRequest.h` or `AffirmClient.h` files.
