### PR TITLE
fix: add dynamic region switching support (locale, countryCode, currency)

### DIFF
--- a/AffirmSDK/AffirmConfiguration.h
+++ b/AffirmSDK/AffirmConfiguration.h
@@ -149,6 +149,33 @@ NS_SWIFT_NAME(configure(publicKey:environment:locale:countryCode:currency:mercha
  */
 + (void)deleteAffirmCookies;
 
+/**
+ Updates the locale used by Affirm after initialization.
+ Use this to dynamically switch regions without requiring an app relaunch.
+
+ @param locale The locale string (e.g., "en_US", "en_CA", "en_GB").
+ */
+- (void)setLocale:(NSString *)locale
+NS_SWIFT_NAME(setLocale(_:));
+
+/**
+ Updates the country code used by Affirm after initialization.
+ Use this to dynamically switch regions without requiring an app relaunch.
+
+ @param countryCode The country code string (e.g., "USA", "CAN", "GBR").
+ */
+- (void)setCountryCode:(NSString *)countryCode
+NS_SWIFT_NAME(setCountryCode(_:));
+
+/**
+ Updates the currency used by Affirm after initialization.
+ Use this to dynamically switch regions without requiring an app relaunch.
+
+ @param currency The currency string (e.g., "USD", "CAD", "GBP").
+ */
+- (void)setCurrency:(NSString *)currency
+NS_SWIFT_NAME(setCurrency(_:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AffirmSDK/AffirmConfiguration.m
+++ b/AffirmSDK/AffirmConfiguration.m
@@ -207,4 +207,31 @@
     [AffirmConfiguration sharedInstance].pool = nil;
 }
 
+- (void)setLocale:(NSString *)locale
+{
+    if (locale == nil || locale.length == 0) {
+        [[AffirmLogger sharedInstance] logException:@"Locale is empty. Please provide a valid locale string."];
+        return;
+    }
+    _locale = [locale copy];
+}
+
+- (void)setCountryCode:(NSString *)countryCode
+{
+    if (countryCode == nil || countryCode.length == 0) {
+        [[AffirmLogger sharedInstance] logException:@"Country code is empty. Please provide a valid country code."];
+        return;
+    }
+    _countryCode = [countryCode copy];
+}
+
+- (void)setCurrency:(NSString *)currency
+{
+    if (currency == nil || currency.length == 0) {
+        [[AffirmLogger sharedInstance] logException:@"Currency is empty. Please provide a valid currency string."];
+        return;
+    }
+    _currency = [currency copy];
+}
+
 @end

--- a/AffirmSDK/AffirmConfiguration.m
+++ b/AffirmSDK/AffirmConfiguration.m
@@ -68,6 +68,9 @@
 {
     self.publicKey = [publicKey copy];
     self.environment = environment;
+    self.locale = AFFIRM_DEFAULT_LOCALE;
+    self.countryCode = AFFIRM_DEFAULT_COUNTRY_CODE;
+    self.currency = AFFIRM_DEFAULT_CURRENCY;
     self.merchantName = [merchantName copy];
 }
 

--- a/AffirmSDKTests/AffirmConfigurationTests.m
+++ b/AffirmSDKTests/AffirmConfigurationTests.m
@@ -33,4 +33,101 @@
     XCTAssertEqualObjects([AffirmConfiguration sharedInstance].publicKey, @"OKSJJASBDJBAJBC");
 }
 
+- (void)testSimpleConfigureResetsLocaleCountryCodeCurrency
+{
+    // First configure with CA settings
+    [[AffirmConfiguration sharedInstance] configureWithPublicKey:@"CA_KEY"
+                                                    environment:AffirmEnvironmentSandbox
+                                                         locale:@"en_CA"
+                                                    countryCode:@"CAN"
+                                                       currency:@"CAD"
+                                                   merchantName:nil];
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].locale, @"en_CA");
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].countryCode, @"CAN");
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].currency, @"CAD");
+
+    // Now re-configure with simple method (simulating region switch with new public key)
+    [[AffirmConfiguration sharedInstance] configureWithPublicKey:@"UK_KEY"
+                                                    environment:AffirmEnvironmentSandbox];
+
+    // locale, countryCode, currency should be reset to defaults
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].locale, @"en_US");
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].countryCode, @"USA");
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].currency, @"USD");
+}
+
+- (void)testFullConfigureUpdatesLocaleCountryCodeCurrency
+{
+    [[AffirmConfiguration sharedInstance] configureWithPublicKey:@"UK_KEY"
+                                                    environment:AffirmEnvironmentSandbox
+                                                         locale:@"en_GB"
+                                                    countryCode:@"GBR"
+                                                       currency:@"GBP"
+                                                   merchantName:nil];
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].locale, @"en_GB");
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].countryCode, @"GBR");
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].currency, @"GBP");
+}
+
+- (void)testSetLocale
+{
+    [[AffirmConfiguration sharedInstance] setLocale:@"en_GB"];
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].locale, @"en_GB");
+}
+
+- (void)testSetCountryCode
+{
+    [[AffirmConfiguration sharedInstance] setCountryCode:@"GBR"];
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].countryCode, @"GBR");
+}
+
+- (void)testSetCurrency
+{
+    [[AffirmConfiguration sharedInstance] setCurrency:@"GBP"];
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].currency, @"GBP");
+}
+
+- (void)testRegionSwitchCAtoUK
+{
+    // Start with CA config
+    [[AffirmConfiguration sharedInstance] configureWithPublicKey:@"CA_KEY"
+                                                    environment:AffirmEnvironmentSandbox
+                                                         locale:@"en_CA"
+                                                    countryCode:@"CAN"
+                                                       currency:@"CAD"
+                                                   merchantName:nil];
+
+    // Switch to UK using full configure (like Android re-initialization)
+    [[AffirmConfiguration sharedInstance] configureWithPublicKey:@"UK_KEY"
+                                                    environment:AffirmEnvironmentSandbox
+                                                         locale:@"en_GB"
+                                                    countryCode:@"GBR"
+                                                       currency:@"GBP"
+                                                   merchantName:nil];
+
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].locale, @"en_GB");
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].countryCode, @"GBR");
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].currency, @"GBP");
+}
+
+- (void)testRegionSwitchCAtoUKUsingSetters
+{
+    // Start with CA config
+    [[AffirmConfiguration sharedInstance] configureWithPublicKey:@"CA_KEY"
+                                                    environment:AffirmEnvironmentSandbox
+                                                         locale:@"en_CA"
+                                                    countryCode:@"CAN"
+                                                       currency:@"CAD"
+                                                   merchantName:nil];
+
+    // Switch to UK using individual setters
+    [[AffirmConfiguration sharedInstance] setLocale:@"en_GB"];
+    [[AffirmConfiguration sharedInstance] setCountryCode:@"GBR"];
+    [[AffirmConfiguration sharedInstance] setCurrency:@"GBP"];
+
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].locale, @"en_GB");
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].countryCode, @"GBR");
+    XCTAssertEqualObjects([AffirmConfiguration sharedInstance].currency, @"GBP");
+}
+
 @end


### PR DESCRIPTION
## Summary
- Adds public setter methods setLocale:, setCountryCode:, and setCurrency: to AffirmConfiguration
- Enables merchants to dynamically switch between regions (e.g., CA to UK) within the same app session without requiring an app relaunch

## Problem
When a merchant app switches shipping address from Canada (CAD) to UK (GBP) within the same session, the SDK meta.locale field remains set to en_CA. This causes checkout failures with: currency GBP is not supported for country CAN.

The SDK had no public API to update locale, countryCode, or currency individually after initial configuration.

## Solution
Added three new public methods to AffirmConfiguration:
- setLocale: - updates the locale (e.g., en_GB)
- setCountryCode: - updates the country code (e.g., GBR)
- setCurrency: - updates the currency (e.g., GBP)

Each setter validates input (non-nil, non-empty) and logs a warning on invalid input.

## Test plan
- [ ] Verify setLocale: updates checkout meta.locale and request headers
- [ ] Verify setCountryCode: updates promo/tracker URL selection and request headers
- [ ] Verify setCurrency: updates the currency sent in checkout request body
- [ ] Verify switching from CA config to UK config mid-session works
- [ ] Verify passing nil or empty string logs warning and does not update values